### PR TITLE
Update chegg_bot_answer.py

### DIFF
--- a/chegg_bot_answer.py
+++ b/chegg_bot_answer.py
@@ -106,8 +106,8 @@ request_queue = []
 flag = False
 client = commands.Bot(command_prefix='!')
 
-_2captcha_key = 'cb319d881ccd6998c30ae4a94c9cc666'
-bot_token = 'NjUxNzk4MDM0Mzc5NzAyMjgz.XfarEA.KbHfalMvK13ZIiwaXeeW1lBK3sc'
+_2captcha_key = os.environ['2capToken'] #You should move your tokens to enviroment variables, so that they wont be visible on github.
+bot_token = os.environ['BotToken']      #If you don't, people may use these maliciously.
 
 
 @client.event


### PR DESCRIPTION
The discord token is not needed by anyone using this bot, they will need to generate their own anyway and add it themselves. For security reasons you should never leave api keys, tokens, or passwords, in your code where they can be publicly viewed. If you make an enviroment variable, you can grab it from your code by importing the os library and calling os.environ[your_variable], and it stays on your machine without being visible in the code. Just remember when you set one, you need to restart your computer before you can call it. Not sure why, that's just how it works.